### PR TITLE
Allow Templates to @include other templates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,68 +37,64 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     stat_find='-f'
 fi
 
-function build_page() {
-    # page=$0;
-    # create an html file with the same name as the descriptor file
-    # see https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
-    filename="${page#pages/}"
-    html=www/"${filename%.*}".html
-    rm -f $html
-    touch $html
-
-    # process all descriptors in the descriptor file
-    while read -r descriptor
-    do
-        # check whether the current line defines parameter values
-        if [[ $descriptor == @param* ]]; then
-            # we remove everything after "@params " and execute it,
-            # then we jump to the next line
-            eval "export ${descriptor#@param }"
-            continue
-        fi
-
-        # find the template(s) matching the descriptor, possibly more
-        # than one per line, separated by semicolons
-        declare -a template_names="(${descriptor//;/ })";
-        rm -f tmp.html
-        for template in ${template_names[*]}; do
-            # Replace @include inside a template
-            include_pattern='(.*)@include=(.*)'
-            rm -f template.html
-            while IFS= read line; do
-                if [[ $line =~ $include_pattern ]]; then
-                    # Preserve indents; prefix each line with spacing.
-                    sed -e "s/^/${BASH_REMATCH[1]}/" templates/${BASH_REMATCH[2]}.tmp >> template.html
-                else
-                    echo "$line" >> template.html
-                fi
-            done < "templates/$template.tmp"
-
-            # append to the temporary HTML file, evaluating any possible params
-            envsubst < template.html >> tmp.html
-            rm -f template.html
-        done
-
-        if grep -q @content $html; then
-            # replace the @content string for the contents of the template file
-            sed -e '/@content/ {' -e 'r tmp.html' -e 'd' -e '}' -i "" $html
-        else
-            cat tmp.html >> $html
-        fi
-        # fix char encoding in case sed has messed it up
-        iconv -f `file -I $html | cut -f2 -d=` -t UTF-8 $html > iconv.out
-        mv -f iconv.out $html
-    done < "$page"
-
-    rm -f tmp.html
-    rm -f iconv.out
-}
-
 # iterate over all .snp page descriptor files
 function build() {
-    for page in `ls pages/ad*.snp`; do
+    for page in `ls pages/*.snp`; do
         echo "Building $page..."
-        build_page $page
+
+        # create an html file with the same name as the descriptor file
+        # see https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
+        filename="${page#pages/}"
+        html=www/"${filename%.*}".html
+        rm -f $html
+        touch $html
+
+        # process all descriptors in the descriptor file
+        while read -r descriptor
+        do
+            # check whether the current line defines parameter values
+            if [[ $descriptor == @param* ]]; then
+                # we remove everything after "@params " and execute it,
+                # then we jump to the next line
+                eval "export ${descriptor#@param }"
+                continue
+            fi
+
+            # find the template(s) matching the descriptor, possibly more
+            # than one per line, separated by semicolons
+            declare -a template_names="(${descriptor//;/ })";
+            rm -f tmp.html
+            for template in ${template_names[*]}; do
+                # Replace @include inside a template
+                include_pattern='(.*)@include=(.*)'
+                rm -f template.html
+                while IFS= read line; do
+                    if [[ $line =~ $include_pattern ]]; then
+                        # Preserve indents; prefix each line with spacing.
+                        sed -e "s/^/${BASH_REMATCH[1]}/" templates/${BASH_REMATCH[2]}.tmp >> template.html
+                    else
+                        echo "$line" >> template.html
+                    fi
+                done < "templates/$template.tmp"
+
+                # append to the temporary HTML file, evaluating any possible params
+                envsubst < template.html >> tmp.html
+                rm -f template.html
+            done
+
+            if grep -q @content $html; then
+                # replace the @content string for the contents of the template file
+                sed -e '/@content/ {' -e 'r tmp.html' -e 'd' -e '}' -i "" $html
+            else
+                cat tmp.html >> $html
+            fi
+            # fix char encoding in case sed has messed it up
+            iconv -f `file -I $html | cut -f2 -d=` -t UTF-8 $html > iconv.out
+            mv -f iconv.out $html
+        done < "$page"
+
+        rm -f tmp.html
+        rm -f iconv.out
     done
 
     # copy over all static files

--- a/build.sh
+++ b/build.sh
@@ -62,19 +62,17 @@ function build_page() {
         declare -a template_names="(${descriptor//;/ })";
         rm -f tmp.html
         for template in ${template_names[*]}; do
-            template_path="templates/$template.tmp"
-
-            # Replace @include with templates
-            include_name='(.*)@include=(.*)'
+            # Replace @include inside a template
+            include_pattern='(.*)@include=(.*)'
             rm -f template.html
             while IFS= read line; do
-                if [[ $line =~ $include_name ]]; then
-                    echo "MATCHED ${BASH_REMATCH[1]}"
+                if [[ $line =~ $include_pattern ]]; then
+                    # Preserve indents; prefix each line with spacing.
                     sed -e "s/^/${BASH_REMATCH[1]}/" templates/${BASH_REMATCH[2]}.tmp >> template.html
                 else
                     echo "$line" >> template.html
                 fi
-            done < "$template_path"
+            done < "templates/$template.tmp"
 
             # append to the temporary HTML file, evaluating any possible params
             envsubst < template.html >> tmp.html
@@ -98,7 +96,7 @@ function build_page() {
 
 # iterate over all .snp page descriptor files
 function build() {
-    for page in `ls pages/*.snp`; do
+    for page in `ls pages/ad*.snp`; do
         echo "Building $page..."
         build_page $page
     done

--- a/pages/admin.snp
+++ b/pages/admin.snp
@@ -1,4 +1,3 @@
 base
-@param title="Test"
 admin
 base-bottom

--- a/pages/admin.snp
+++ b/pages/admin.snp
@@ -1,3 +1,4 @@
 base
+@param title="Test"
 admin
 base-bottom

--- a/templates/base.tmp
+++ b/templates/base.tmp
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <meta charset="UTF-8">
+        @include=head
         <title>Snap! Build Your Own Blocks</title>
         <meta name="description" content="The Snap! social platform">
         <meta name="author" content="Bernat Romagosa">

--- a/templates/head.tmp
+++ b/templates/head.tmp
@@ -1,0 +1,1 @@
+<meta charset="UTF-8">


### PR DESCRIPTION
This extends the build system to support `@include=template` within a template file.

Hopefully, this will make some things a little easier to read. I think that smaller HTML pieces are easier to understand, and it's also nice when you don't have to keep track of indentation in separate files. (This takes care to put any included content inside the file at the same indentation level.)


The including happens before variables are substituted - so includes work with variables.
It also isn't extracted into a function, so you can't include more than one level deep, but that seems OK for now. It also could be sped up by caching the inclusions and them reading from a saved file if a template is common (like in base.tmp), but I also think that can come later if needed. 

The example of the `head.tmp` is just to show that when building the output doesn't change. 