### PR TITLE
Fix Zombie Admin searching for only Zombie Accounts

### DIFF
--- a/static/style/admin.css
+++ b/static/style/admin.css
@@ -1,4 +1,4 @@
-.user_admin .user {
+.user_admin .user, .zombie_admin .user {
     padding: 0.5em;
     box-sizing: border-box;
 }
@@ -65,16 +65,16 @@
     margin-top: 0.5em;
 }
 
-.user_admin.search {
+.user_admin.search, .zombie_admin.search {
     margin-left: 0.5em;
     width: 220px;
 }
 
-.user_admin.search form {
+.user_admin.search form, .zombie_admin.search form {
     position: relative;
 }
 
-.user_admin.search input {
+.user_admin.search input, .zombie_admin.search input {
     width: 100%;
     height: 2em;
     padding-left: 0.75em;
@@ -84,7 +84,7 @@
     border: 1px solid #AAAAAA;
 }
 
-.user_admin.search i {
+.user_admin.search i, .zombie_admin.search i {
     position: absolute;
     right: 0.45em;
     top: 0.45em;

--- a/templates/zombie_admin.tmp
+++ b/templates/zombie_admin.tmp
@@ -11,13 +11,13 @@
 @param pageSize=150
 @param withSearch=true
 @param keepIfEmpty=true
-@param widgetName=user_admin
+@param widgetName=zombie_admin
 @include=grid
 @param keepIfEmpty=false
 <script>
     var role = '',
         verified = '';
-    user_admin_loadPage =
+    zombie_admin_loadPage =
         function (query, pageSize, pageNumber, onSuccess) {
             SnapCloud.withCredentialsRequest(
                 'GET',
@@ -37,12 +37,12 @@
             );
         };
 
-    user_admin_onLoadPage =
+    zombie_admin_onLoadPage =
         function (response, targetElement) {
             response.users.forEach(function (user) {
                 targetElement.appendChild(zombieDiv(user));
             });
         };
 
-    user_admin_initGrid();
+    zombie_admin_initGrid();
 </script>


### PR DESCRIPTION
Since the widget only used user_admin, the grid.tmp then used the user_admin, set as widgetName, in the search form's action parameter, which directed to user_admin as a result

We wanted to redirect to zombie_admin since that will use the query code against the Zombie users as written in zombie_admin.snp, so the widgetName parameter was changed to zombie_admin and the admin.css file added the zombie_admin classes to apply the same styling on the Zombie Admin elements as well