### PR TITLE
Reload the User Admin page upon Verification

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -24,8 +24,7 @@ function verifyButton (user) {
                     alert(
                         response,
                         function () {
-                            location.href = 'user?user=' +
-                                encodeURIComponent(user.username);
+                            location.reload();
                         }
                     );
                 },


### PR DESCRIPTION
When an admin verifies a person, it sends the person to the Verified User’s page

However, the desired behavior is that it will return to the same User Admin page just in case the person wants to verify more people

This fix just reloads the current page upon completion of the Verification of the User